### PR TITLE
Implement gravity computation via force integration

### DIFF
--- a/Rocket.gd
+++ b/Rocket.gd
@@ -1,6 +1,6 @@
 extends RigidBody3D
 
-# Simple rocket controlled by player with gravitational influences from two bodies.
+# Rocket controlled by player and influenced by gravity of two bodies.
 
 const G = 1.0
 
@@ -11,6 +11,7 @@ const G = 1.0
 @export var target_radius: float = 1.0
 
 @export var thrust_force: float = 20.0
+@export var thrust_consumption: float = 1.0
 @export var rocket_mass: float = 1.0
 @export var fuel_max: float = 5.0
 @export var start_offset: Vector3 = Vector3(0, 0, 1.2)
@@ -25,28 +26,29 @@ func _ready():
     if target_body:
         look_at(target_body.global_transform.origin, Vector3.UP)
 
-func _physics_process(delta):
+func compute_gravity(p: Vector3, center: Vector3, mass_val: float) -> Vector3:
+    var dir = center - p
+    var dist_sq = dir.length_squared()
+    if dist_sq == 0.0:
+        return Vector3.ZERO
+    return G * mass_val / dist_sq * dir.normalized()
+
+func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
     var acc = Vector3.ZERO
     var pos = global_transform.origin
 
     if start_body:
-        var dir = start_body.global_transform.origin - pos
-        var dist2 = dir.length_squared()
-        if dist2 > 0.0:
-            acc += G * mass_start / dist2 * dir.normalized()
-
+        acc += compute_gravity(pos, start_body.global_transform.origin, mass_start)
     if target_body:
-        var dir2 = target_body.global_transform.origin - pos
-        var dist22 = dir2.length_squared()
-        if dist22 > 0.0:
-            acc += G * mass_target / dist22 * dir2.normalized()
+        acc += compute_gravity(pos, target_body.global_transform.origin, mass_target)
+
+    add_central_force(acc * mass)
 
     if Input.is_action_pressed("ui_accept") and fuel > 0.0:
-        acc += -global_transform.basis.z * (thrust_force / rocket_mass)
-        fuel = max(0.0, fuel - delta)
+        add_central_force(-global_transform.basis.z * thrust_force)
+        fuel = max(0.0, fuel - thrust_consumption * state.step)
 
-    linear_velocity += acc * delta
-
+func _physics_process(delta: float) -> void:
     var rot_input := 0.0
     if Input.is_action_pressed("ui_left"):
         rot_input += 1.0
@@ -57,6 +59,6 @@ func _physics_process(delta):
     else:
         angular_velocity.y = 0.0
 
-    if target_body and (target_body.global_transform.origin - pos).length() <= target_radius:
+    if target_body and (target_body.global_transform.origin - global_transform.origin).length() <= target_radius:
         print("Victory: reached target")
         set_physics_process(false)


### PR DESCRIPTION
## Summary
- refactor rocket physics to use `_integrate_forces`
- add `compute_gravity` helper
- account for thrust force and fuel consumption per physics step
- keep rotation controls in `_physics_process`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ebe33d50832582e7e30d4344d5fa